### PR TITLE
SeattleJSConference fix console warnings

### DIFF
--- a/seattlejsconference/presentation/index.js
+++ b/seattlejsconference/presentation/index.js
@@ -81,7 +81,7 @@ export default class Presentation extends React.Component {
 
     const sponsor = {
       display: "block",
-      marginBottom: "1.5em"
+      margin: "0.5rem auto 1.5em"
     };
 
     const wifiSlide = (
@@ -97,7 +97,7 @@ export default class Presentation extends React.Component {
             <Text>foundry98103</Text>
           </Fill>
         </Layout>
-        <Text style={{ marginBottom: 0 }}>
+        <Text style={{ margin: "1.25rem auto 0" }}>
           <Link href="https://twitter.com/seattlejs">
             <Image
               height="1.5em"
@@ -107,7 +107,7 @@ export default class Presentation extends React.Component {
             @SeattleJS
           </Link>
         </Text>
-        <Text style={{ marginTop: 0, marginBottom: "3em" }}>
+        <Text style={{ margin: "0 auto 3em" }}>
           <Link href="https://twitter.com/hashtag/SeattleJSConf?src=hash">
             <Image
               height="1.5em"

--- a/seattlejsconference/themes/seattlejs/screen.js
+++ b/seattlejsconference/themes/seattlejs/screen.js
@@ -77,6 +77,17 @@ const customTheme = {
       color: colors.primary
     }
   },
+  fullscreen: {
+    fill: colors.white
+  },
+  autoplay: {
+    pauseIcon: {
+      fill: colors.white
+    },
+    playIcon: {
+      fill: colors.white
+    }
+  },
   controls: {
     prevIcon: {
       fill: colors.primary

--- a/seattlejsconference/themes/seattlejs/screen.js
+++ b/seattlejsconference/themes/seattlejs/screen.js
@@ -150,21 +150,13 @@ const customTheme = {
       }
     },
     image: {
-      margin: null,
-      marginTop: "0.5rem",
-      marginRight: "auto", 
-      marginBottom: "0.5rem",
-      marginLeft: "auto"
+      margin: "0.5rem auto"
     },
     text: {
       color: colors.primary,
       fontSize: "2rem",
       fontFamily: fonts.body,
-      margin: null,
-      marginTop: "1.25rem",
-      marginRight: "auto", 
-      marginBottom: "1.25rem",
-      marginLeft: "auto"
+      margin: "1.25rem auto"
     }
   }
 };


### PR DESCRIPTION
- Use shorthand `margin` property everywhere to resolve Radium longhand shorthand warnings
- Change icon colors to white 